### PR TITLE
makes shutdown use shrink to keep _size consistent

### DIFF
--- a/workerpool/pools.py
+++ b/workerpool/pools.py
@@ -83,7 +83,7 @@ class WorkerPool(Queue):
     def shutdown(self):
         "Retire the workers."
         for i in xrange(self.size()):
-            self.put(SuicideJob())
+            self.shrink()
 
     def size(self):
         "Approximate number of active workers"


### PR DESCRIPTION
The current implementation allows a user to call shutdown(), then later call size() and get a nonzero value even though all the workers have terminated.
